### PR TITLE
Cache admin user, so that we don't invalidate a bunch of temporary admin sessions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>BridgeIntegTestUtils</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This is necessary once the changes in https://github.com/Sage-Bionetworks/BridgePF/pull/1716 are merged.