### PR TITLE
Accounts being left in the shared study because the admin isn't in that study when it deletes the user.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>BridgeIntegTestUtils</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.9</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/sagebionetworks/bridge/user/TestUserHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/user/TestUserHelper.java
@@ -111,10 +111,19 @@ public class TestUserHelper {
                 }
             }
             if (userId != null) {
-                // This should sign the admin manager in automatically.
                 TestUser admin = getSignedInAdmin();
+                boolean adminInWrongStudy = !getStudyId().equals(admin.getStudyId());
+                ForSuperadminsApi superadminsApi = admin.getClient(ForSuperadminsApi.class);
+                // If admin is in a different study, switch to the user's study before deletion.
+                if (adminInWrongStudy) {
+                    superadminsApi.adminChangeStudy(new SignIn().study(getStudyId())).execute();
+                }
                 ForAdminsApi adminsApi = admin.getClient(ForAdminsApi.class);
                 adminsApi.deleteUser(userId).execute();
+                // then switch back
+                if (adminInWrongStudy) {
+                    superadminsApi.adminChangeStudy(new SignIn().study(STUDY_ID)).execute();
+                }
             }
         }
         public SignIn getSignIn() {


### PR DESCRIPTION
This checks and changes the admins study to the right study before doing the deletion. Verified that shared account is no longer accumulating test accounts.