### PR TITLE
BRIDGE-3152 (integration tests in production)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>BridgeIntegTestUtils</artifactId>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.21.15</version>
+            <version>0.23.9</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.23.9</version>
+            <version>0.23.11</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/sagebionetworks/bridge/user/TestUserHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/user/TestUserHelper.java
@@ -43,6 +43,10 @@ public class TestUserHelper {
     private static final SignIn API_SIGN_IN = new SignIn().appId(TEST_APP_ID);
     private static final String ADMIN_EMAIL_PROPERTY = "admin.email";
     private static final String ADMIN_PASSWORD_PROPERTY = "admin.password";
+    private static final SignIn ADMIN_SIGN_IN = new SignIn()
+            .appId(TEST_APP_ID)
+            .email(CONFIG.get(ADMIN_EMAIL_PROPERTY))
+            .password(CONFIG.get(ADMIN_PASSWORD_PROPERTY));
 
     private static final List<String> LANGUAGES = Lists.newArrayList("en");
     private static final String PASSWORD = "P4ssword!";
@@ -160,10 +164,7 @@ public class TestUserHelper {
      */
     public static TestUser getSignedInAdmin() {
         if (cachedAdmin == null) {
-            SignIn signIn = API_SIGN_IN
-                    .email(CONFIG.get(ADMIN_EMAIL_PROPERTY))
-                    .password(CONFIG.get(ADMIN_PASSWORD_PROPERTY));
-            cachedAdmin = getSignedInUser(signIn);
+            cachedAdmin = getSignedInUser(ADMIN_SIGN_IN);
         }
         if (cachedAdmin.getAppId() != TEST_APP_ID) {
             try {

--- a/src/main/java/org/sagebionetworks/bridge/util/IntegTestUtils.java
+++ b/src/main/java/org/sagebionetworks/bridge/util/IntegTestUtils.java
@@ -10,15 +10,24 @@ import org.sagebionetworks.bridge.rest.model.AccountSummaryList;
 import org.sagebionetworks.bridge.rest.model.AccountSummarySearch;
 import org.sagebionetworks.bridge.rest.model.Phone;
 import org.sagebionetworks.bridge.user.TestUserHelper;
+import org.sagebionetworks.bridge.user.TestUserHelper.TestUser;
 
 public class IntegTestUtils {
-    public static final Config CONFIG = new Config();
+    
     public static final Phone PHONE = new Phone().number("+19712486796").regionCode("US");
     public static final String TEST_APP_ID = "api";
     public static final String SHARED_APP_ID = "shared";
     public static final String SAGE_ID = "sage-bionetworks";
     public static final String SAGE_NAME = "Sage Bionetworks";
+    
+    private static final String CONFIG_FILE = "/bridge-sdk.properties";
+    private static final String USER_CONFIG_FILE = System.getProperty("user.home") + "/bridge-sdk.properties";
 
+    private static final String SDK_TEST_FILE = "/bridge-sdk-test.properties";
+    private static final String USER_SDK_TEST_FILE = System.getProperty("user.home") + SDK_TEST_FILE;
+    
+    public static final Config CONFIG = new Config(CONFIG_FILE, USER_CONFIG_FILE, SDK_TEST_FILE, USER_SDK_TEST_FILE);
+    
     public static void deletePhoneUser() throws IOException {
         TestUserHelper.TestUser admin = TestUserHelper.getSignedInAdmin();
 
@@ -33,7 +42,7 @@ public class IntegTestUtils {
     }
 
     public static String makeEmail(Class<?> cls) {
-        String devName = CONFIG.getDevName();
+        String devName = CONFIG.get("dev.name");
         String clsPart = cls.getSimpleName();
         String rndPart = RandomStringUtils.randomAlphabetic(4);
         return String.format("bridge-testing+%s-%s-%s@sagebase.org", devName, clsPart, rndPart);


### PR DESCRIPTION
- Use the SDK’s configuration object to create a `IntegTestUtils.CONFIG` static variable, with a configuration for all our integration test code in `BridgeIntegTestUtils` and `BridgeIntegrationTests`. Otherwise, `BridgeIntegTestUtils` cannot read properties in the `bridge-sdk-test.properties` file.
- Remove the two superadmin APIs we’ve removed from `BridgeServer2` to adjust tests more toward the use of an admin, not a superadmin.